### PR TITLE
Prevent infinite loops on pages bigger than 2MB

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    palapala_pdf (0.1.20)
+    palapala_pdf (0.1.21)
       base64 (~> 0)
       combine_pdf (~> 1)
       websocket-driver (~> 0)

--- a/lib/palapala/renderer.rb
+++ b/lib/palapala/renderer.rb
@@ -88,6 +88,8 @@ module Palapala
     # Method to send a CDP command and wait for a specific method to be called
     def send_command_and_wait_for_event(method, event_name:, params: {})
       send_command(method, params:) do
+        # chrome refuses to load pages that are bigger than 2MB and returns a net::ERR_ABORTED error
+        raise "Page cannot be loaded" if @response.dig("result", "errorText") == "net::ERR_ABORTED"
         @response && @response["method"] == event_name
       end
     end

--- a/lib/palapala/version.rb
+++ b/lib/palapala/version.rb
@@ -1,3 +1,3 @@
 module Palapala
-  VERSION = "0.1.20"
+  VERSION = "0.1.21"
 end


### PR DESCRIPTION
`Chrome` refuses to load pages bigger than 2MB, and this causes an infinite loop in the library because we're not checking for that possibility.

This should fix the problem by raising an exception when this kind of error is detected.